### PR TITLE
Fix "isSaved" flag for 1kproject create expense script

### DIFF
--- a/1kproject/create-expenses.js
+++ b/1kproject/create-expenses.js
@@ -8,7 +8,7 @@ const { Command } = require('commander');
 const csvParseSync = require('csv-parse/sync'); // eslint-disable-line node/no-missing-require
 
 const { request, gql } = require('graphql-request');
-const prompt = require("prompt");
+const prompt = require('prompt');
 
 const endpoint = `${process.env.API_URL}/graphql/v2/${process.env.API_KEY}`;
 const WISE_API_URL = process.env.TRANSFERWISE_API_URL || 'https://api.transferwise.com';
@@ -144,6 +144,7 @@ async function main(argv = process.argv) {
         description: `${name} Family`,
         payoutMethod: {
           type: 'BANK_ACCOUNT',
+          isSaved: false,
           data: {
             type: 'CARD',
             details: {
@@ -159,7 +160,6 @@ async function main(argv = process.argv) {
             },
             currency: 'UAH',
             accountHolderName: name,
-            isSaved: false
           },
         },
       },
@@ -194,9 +194,14 @@ async function main(argv = process.argv) {
           } catch (e) {
             if (e.message.includes('Two-factor authentication')) {
               tfaPrompt = await prompt.get({ name: 'tfa', description: '2FA Code' });
-              await request(endpoint, processExpenseMutation, { expenseId: result.createExpense.id, action: 'APPROVE' }, {
-                'x-two-factor-authentication': `totp ${tfaPrompt.tfa}`,
-              });
+              await request(
+                endpoint,
+                processExpenseMutation,
+                { expenseId: result.createExpense.id, action: 'APPROVE' },
+                {
+                  'x-two-factor-authentication': `totp ${tfaPrompt.tfa}`,
+                },
+              );
             } else {
               throw e;
             }


### PR DESCRIPTION
Noticed while inspecting the expense page query, I was getting a huge payload as a response (2590 payout methods).

Already marked impacted entries as `isSaved=false`:

```sql
select * from "PayoutMethods" where "CollectiveId" = 489019 AND "isSaved" IS TRUE
AND "deletedAt" IS NULL
AND "type" = 'BANK_ACCOUNT'
ORDER BY "createdAt" ASC
```

The `updatedAt` for all these entries is `2023-03-21 09:51:31.767000 +00:00`