### PR TITLE
Correct the Manjaro mapping from `manjaro-us` to `manjaro`

### DIFF
--- a/github-sponsors/csv-import-mapping.json
+++ b/github-sponsors/csv-import-mapping.json
@@ -182,7 +182,7 @@
   "LycheeOrg": "lycheeorg",
   "macports": "macports",
   "macvim-dev": "macvim",
-  "manjaro-sway": "manjaro-us",
+  "manjaro-sway": "manjaro",
   "maplibre": "maplibre",
   "mapstruct": "mapstruct",
   "mathesar-foundation": "mathesar",


### PR DESCRIPTION
As per discussion in Slack at, https://oficonsortium.slack.com/archives/C08R795RUDC/p1747319020075109 we've changed the mapping