### PR TITLE
Increase sleep for API rate limit prevention

### DIFF
--- a/github-sponsors/csv-import.js
+++ b/github-sponsors/csv-import.js
@@ -202,7 +202,7 @@ async function main(argv = process.argv) {
     );
 
     // Poor man rate-limiting (100 req / minute max on the API)
-    await sleep(1000);
+    await sleep(5000);
 
     if (options.run) {
       const result = await request(endpoint, addFundsMutation, variables);


### PR DESCRIPTION
I've increased this `sleep` amount as OSC's large GitHub import constantly hits rate limiting on the API side