### PR TITLE
fix(ci): update Node.js version matrix from 18.x/20.x to 24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The project requires Node.js >=24 (package.json engines) and .nvmrc specifies Node 24, but CI was testing against Node 18.x and 20.x, causing failures since dependencies and code require Node 24+.
